### PR TITLE
Fix backwards compatibility

### DIFF
--- a/Import.php
+++ b/Import.php
@@ -27,9 +27,9 @@ class Import
       * @param $database string database name
       * @param $host string address host localhost or ip address
       * @param $dropTables boolean When set to true delete the database tables
-      * @param $forceDropTables boolean When set to true foreign key checks will be disabled during deletion
+      * @param $forceDropTables boolean [optional] When set to true foreign key checks will be disabled during deletion
     */
-    public function __construct($filename, $username, $password, $database, $host, $dropTables, $forceDropTables)
+    public function __construct($filename, $username, $password, $database, $host, $dropTables, $forceDropTables = false)
     {
         //set the varibles to properties
         $this->filename = $filename;


### PR DESCRIPTION
Fix backwards incompatibility caused by new feature #1 (see #3).
The newly added feature added a new constructor parameter that is not
set in existing applications, causing an exception.
The parameter is now set to false by default as it is generally
considered dangerous to disable foreign key checks.